### PR TITLE
Fixing buildpack so it downloads properly

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -21,6 +21,7 @@ cd $1
 
 while read url; do
   if [ -n "$url" ]; then
+    mkdir -p bin
     echo Vendoring $url | indent
     curl -L "$url" -o $1/bin/terraform.zip
     if [ $? -ne 0 ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -22,7 +22,11 @@ cd $1
 while read url; do
   if [ -n "$url" ]; then
     echo Vendoring $url | indent
-    curl -L --silent $url > $1/bin/terraform.zip
+    curl -L "$url" -o $1/bin/terraform.zip
+    if [ $? -ne 0 ]; then
+        >&2 echo "Couldn't download $url" 
+        exit 1
+    fi
     cd $1/bin && $UNZIP_COMMAND terraform.zip && rm terraform.zip
   fi
 done < .terraform_url

--- a/bin/compile
+++ b/bin/compile
@@ -17,17 +17,15 @@ if [ $STACK == "cedar" ]; then
   UNZIP_COMMAND="jar xf"
 fi
 
-cd $1
-
 while read url; do
   if [ -n "$url" ]; then
-    mkdir -p bin
+    mkdir -p "$1/bin"
     echo Vendoring $url | indent
-    curl -L "$url" -o $1/bin/terraform.zip
+    curl -L "$url" -o "$1/bin/terraform.zip"
     if [ $? -ne 0 ]; then
         >&2 echo "Couldn't download $url" 
         exit 1
     fi
     cd $1/bin && $UNZIP_COMMAND terraform.zip && rm terraform.zip
   fi
-done < .terraform_url
+done < $1/.terraform_url

--- a/bin/detect
+++ b/bin/detect
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -f $1/.terraform_url ]; then
-    echo "PackerBinaries"
+    echo "TerraformBinaries"
     exit 0
 else
     exit 1


### PR DESCRIPTION
For some reason current master version of terraform buildpack was not able to download to bin directory. I've changed following things:
- showing the output of curl 
- failing fast when download failed
- creating bin directory when one doesn't exist
- using absolute paths instead of cd to $1
